### PR TITLE
Modal fix

### DIFF
--- a/src/app/@modal/(.)img/[id]/modal.tsx
+++ b/src/app/@modal/(.)img/[id]/modal.tsx
@@ -26,7 +26,6 @@ export function Modal({ children }: { children: React.ReactNode }) {
       onClick={onDismiss}
     >
       {children}
-      {/* <button onClick={onDismiss} className="close-button" /> */}
     </dialog>,
     document.getElementById("modal-root")!,
   );

--- a/src/app/@modal/(.)img/[id]/modal.tsx
+++ b/src/app/@modal/(.)img/[id]/modal.tsx
@@ -23,6 +23,7 @@ export function Modal({ children }: { children: React.ReactNode }) {
       ref={dialogRef}
       className="absolute h-screen w-screen bg-black/90"
       onClose={onDismiss}
+      onClick={onDismiss}
     >
       {children}
       {/* <button onClick={onDismiss} className="close-button" /> */}

--- a/src/app/@modal/(.)img/[id]/modal.tsx
+++ b/src/app/@modal/(.)img/[id]/modal.tsx
@@ -21,7 +21,8 @@ export function Modal({ children }: { children: React.ReactNode }) {
   return createPortal(
     <dialog
       ref={dialogRef}
-      className="absolute h-screen w-screen bg-black/90"
+      className="absolute flex h-screen w-screen items-center bg-black/90"
+      style={{ top: 0 }}
       onClose={onDismiss}
       onClick={onDismiss}
     >


### PR DESCRIPTION
Added some new behaviors to make the user experience better:

onClick dismiss modal. Previously a user would have to click back on mobile or escape on desktop in order to dismiss the modal. Instead i've added an onClick dismiss to make the  experience better overall.

Modal centering. Previously when a user clicked on a picture to see a close up of the image, it would appear as a modal at the top of the screen. This was a problem because if a user scrolls down they wouldn't see the modal they just clicked on. I've changed the behavior to appear in front of the user regardless of where they've scrolled to on the page.